### PR TITLE
gestion de la création par bloc (pour économiser la RAM) et de la sauvegarde en COG

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,14 @@ conda create --name apply_acv --file requirements.txt
 
 # Utilisation
 
-Quatre paramètres:
+Six paramètres:
 
 - l'image et les courbes que l'on doit y appliquer
 - le dossier qui contient les images à corriger
 - le dossier de sortie des traitements (par défaut les images corrigées portent le même nom que les images en entrée)
 - le dossier contenant les courbes à appliquer (au format acv) et les masques correspondant (dans un format compatble avec GDAL)
+- le nombre de lignes par bloc de calcul (option, par défaut : 1000)
+- la compression à appliquer aux images JPEG en sortie (optionnel, par défaut 100: pas de compression)
 
 Par exemple:
 ```
@@ -73,13 +75,15 @@ Le script utilise un environnement python basique.
 
 # Utilisation
 
-Cinq paramètres:
+Sept paramètres:
 
 - le dossier contenant les images à corriger
 - le dossier de sortie des traitements
 - le fichier contenant la liste des images à traiter ainsi que les corrections à leur apporter
 - le dossier contenant les courbes à appliquer (au format acv) et les masques correspondant (dans un format compatible avec GDAL)
 - le nom du fichier de sortie contenant la liste des lignes de commande (optionnel, par défaut : .\cmd.txt)
+- le nombre de lignes par bloc de calcul (optionnel, par défaut : 1000)
+- la compression à appliquer aux images JPEG en sortie (optionnel, par défaut : 90)
 
 Par exemple :
 ````

--- a/create_cmd.py
+++ b/create_cmd.py
@@ -3,6 +3,7 @@
 Script de création des lignes de commande pour appliquer des courbes à un ensemble d'images
 """
 import argparse
+import os
 
 
 def read_args():
@@ -25,6 +26,18 @@ def read_args():
         default="cmd.txt",
     )
     parser.add_argument(
+        "-b",
+        "--blocksize",
+        help="number of lines per block",
+        default=1000
+    )
+    parser.add_argument(
+        "-q",
+        "--quality",
+        help="JPEG Compression quality (100: No compression)",
+        default=90
+    )
+    parser.add_argument(
         "-v", "--verbose", help="verbose (default: 0)", type=int, default=0
     )
     args = parser.parse_args()
@@ -39,14 +52,23 @@ args = read_args()
 
 fOut = open(args.file, "w")
 
+cwd = os.getcwd()
+pathApplyAcv = cwd+"\\apply_acv.py"
+
 for line in open(args.curve):
     fOut.write(
-        "python apply_acv.py -i "
+        "python "
+        + pathApplyAcv
+        + " -i "
         + args.input
         + " -o "
         + args.output
         + " -a "
         + args.acv
+        + " -b "
+        + str(args.blocksize)
+        + " -q "
+        + str(args.quality)
         + " -c "
         + line
     )


### PR DESCRIPTION
# Motivation

Les premiers tests en prod montre une occupation en RAM trop importante, on souhaite se limiter à 5Go de RAM pour pouvoir exploiter un maximum de coeurs sur le serveur.
Il faut aussi prévoir la sauvegarde en COG.

# Démarche

On va appliquer les courbes par blocs, stocker le résultat dans une image en mémoire et faire un CreateCopy en COG à la fin. La taille des blocs sera paramétrable pour être ajuster à 5Go de RAM (en fonction de la taille des OPI).

Deux nouvelles options:

- blocksize: le nombre de ligne de l'image à utiliser pour chaque bloc de traitement (pour l'instant la valeur par défaut est à 1000, mais il faudra l'ajuster)
- quality: le niveau de qualité de la compression Jpeg du COG. Si on indique 100: on ne fait pas de compression Jpeg (ce qui est utile pour vérifier le bon fonctionnement sur l'image de test).